### PR TITLE
Fixed issue where arrays of a primitive type were reporting as 'array[]'

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -245,7 +245,7 @@ var Generator = (function () {
                 };
 
                 if (property.isArray)
-                    property.type = _.has(propin.items, '$ref') ? that.camelCase(propin.items["$ref"].replace("#/definitions/", "")) : propin.type;
+                    property.type = _.has(propin.items, '$ref') ? that.camelCase(propin.items["$ref"].replace("#/definitions/", "")) : propin.items.type;
                 else
                     property.type = _.has(propin, '$ref') ? that.camelCase(propin["$ref"].replace("#/definitions/", "")) : propin.type;
 


### PR DESCRIPTION
For example, take a look at Pet.photoUrls in the petstore example.  This was generating array[] instead of string[].
